### PR TITLE
자료형 도메인 설계하

### DIFF
--- a/src/main/java/com/fastcampus/testdata/domain/SchemaField.java
+++ b/src/main/java/com/fastcampus/testdata/domain/SchemaField.java
@@ -1,5 +1,6 @@
 package com.fastcampus.testdata.domain;
 
+import com.fastcampus.testdata.domain.constant.MockDataType;
 import lombok.*;
 
 @Getter
@@ -8,7 +9,7 @@ import lombok.*;
 public class SchemaField {
 
     private String fieldName;
-    private String mockDataType;
+    private MockDataType mockDataType;
     private Integer fieldOrder;
     private Integer blankPercent;
     private String typeOptionJson;

--- a/src/main/java/com/fastcampus/testdata/domain/constant/MockDataType.java
+++ b/src/main/java/com/fastcampus/testdata/domain/constant/MockDataType.java
@@ -1,0 +1,48 @@
+package com.fastcampus.testdata.domain.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Set;
+
+@RequiredArgsConstructor
+@Getter
+
+public enum MockDataType {
+    STRING(Set.of("minLength", "maxLength", "pattern"), null),
+    NUMBER(Set.of("min", "max", "decimals"), null),
+    BOOLEAN(Set.of(), null),
+    DATETIME(Set.of("from", "to"), null),
+    ENUM(Set.of("elements"), null),
+
+    SENTENCE(Set.of("minSentence", "maxSentence"), STRING),
+    PARAGRAPH(Set.of("minParagraphs", "maxParagraphs"), STRING),
+    UUID(Set.of(), STRING),
+    EMAIL(Set.of(), STRING),
+    CAR(Set.of(), STRING),
+    ROW_NUMBER(Set.of("start", "step"), STRING),
+    NAME(Set.of("sentence"), STRING),
+    ;
+
+    private final Set<String> requiredOptions;
+    private final MockDataType baseType;
+
+    public boolean isBaseType() {
+        return baseType == null;
+    }
+
+    public MockDataTypeObject toObject() {
+        return new MockDataTypeObject(
+                this.name(),
+                this.requiredOptions,
+                this.baseType == null ? null : this.baseType.name()
+        );
+    }
+
+    public record MockDataTypeObject(
+            String name,
+            Set<String> requiredOptions,
+            String baseType
+    ) {}
+
+}

--- a/src/test/java/com/fastcampus/testdata/domain/constant/MockDataTypeTest.java
+++ b/src/test/java/com/fastcampus/testdata/domain/constant/MockDataTypeTest.java
@@ -1,0 +1,40 @@
+package com.fastcampus.testdata.domain.constant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("[Domain] 테스트 데이터 자료형 테스트")
+class MockDataTypeTest {
+
+
+    @DisplayName("쟈료형이 주어지면, 해당 원소의 이름을 리턴한다.")
+    @Test
+    void givenMockDataType_whenReading_thenReturnElementName() {
+
+        //given
+        MockDataType mockDataType = MockDataType.STRING;
+        //when
+        String elementName = mockDataType.toString();
+        //then
+        System.out.println(elementName);
+        assertThat(elementName).isEqualTo(MockDataType.STRING.name());
+
+    }
+
+    @DisplayName("자료형이 주어지면, 해당 원소의 데이터를 리턴한다.")
+    @Test
+    void givenMockDataType_whenReading_thenReturnsEnumElementObject() {
+        // Given
+        MockDataType mockDataType = MockDataType.STRING;
+
+        // When
+        MockDataType.MockDataTypeObject result = mockDataType.toObject();
+
+        // Then
+        assertThat(result.toString())
+                .contains("name", "requiredOptions", "baseType");
+    }
+}


### PR DESCRIPTION
이 pr은 가자 데이터의 자료형 도메인을 enum으로 설계하고, 문자열로 직렬화할 경우에 필요할 것으로 예상하는 정보를 추가로 정의한다.

closes #7 